### PR TITLE
Ability to print non-null terminated buffers added

### DIFF
--- a/SerialLCD.cpp
+++ b/SerialLCD.cpp
@@ -207,6 +207,12 @@ void SerialLCD::print(const char b[])
     SoftwareSerial::write(b);
 }
 
+void SerialLCD::print(const char b[], uint8_t len)
+{
+    SoftwareSerial::write(SLCD_CHAR_HEADER);
+    SoftwareSerial::write(b, len);
+}
+
 void SerialLCD::print(unsigned long n, uint8_t base)
 {
     unsigned char buf[8 * sizeof(long)]; // Assumes 8-bit chars.

--- a/SerialLCD.h
+++ b/SerialLCD.h
@@ -90,6 +90,7 @@ public:
     void backlight(void);
     void print(uint8_t b);
     void print(const char[]);
+    void print(const char[], uint8_t length);
     void print(unsigned long n, uint8_t base);
 
 };


### PR DESCRIPTION
Realized when I tried to first write to a buffer and then write the buffer directly to the screen that Serial LCD lacks a way to output non-null terminated buffers. Hope this is a wanted addition.
