### PR TITLE
Use SoftwareSerial::print instead of own conversion in number conversion...

### DIFF
--- a/SerialLCD.cpp
+++ b/SerialLCD.cpp
@@ -195,7 +195,6 @@ void SerialLCD::backlight(void)
     SoftwareSerial::write(SLCD_BACKLIGHT_ON);   
 }
 // Print Commands
-
 void SerialLCD::print(uint8_t b)
 {
     SoftwareSerial::write(SLCD_CHAR_HEADER);
@@ -209,26 +208,13 @@ void SerialLCD::print(const char b[])
 
 void SerialLCD::print(unsigned long n, uint8_t base)
 {
-    unsigned char buf[8 * sizeof(long)]; // Assumes 8-bit chars.
-    unsigned long i = 0;
-
-    if (base == 0) print(n);
-
-    else if(base!=0)
-    {
-        if (n == 0) {
-            print('0');
-            return;
-        }
-
-        while (n > 0) {
-            buf[i++] = n % base;
-            n /= base;
-        }
-
-        for (; i > 0; i--)
-            print((char) (buf[i - 1] < 10 ?
-                          '0' + buf[i - 1] :
-                          'A' + buf[i - 1] - 10));
-    }
+    SoftwareSerial::write(SLCD_CHAR_HEADER);
+    SoftwareSerial::print(n, base); 
 }
+
+void SerialLCD::write(const char b[], uint8_t len)
+{
+    SoftwareSerial::write(SLCD_CHAR_HEADER);
+    SoftwareSerial::write(b, len);
+}
+

--- a/SerialLCD.h
+++ b/SerialLCD.h
@@ -91,7 +91,7 @@ public:
     void print(uint8_t b);
     void print(const char[]);
     void print(unsigned long n, uint8_t base);
-
+    void write(const char[], uint8_t length);
 };
 
 #endif


### PR DESCRIPTION
Writing number is a lot faster, mostly because they are written in one go, but also get rid of special code and reuse the existing method in SoftwareSerial. Got ~40% speed boost for outputing number that printed 10 chars

Added write (buf, len) to enable writing non-null terminated strings. The reason I needed this is that I realized the overhead of outputting individual characters was huge and I wanted to create a 2x16 char buffer that I prepared in the sketch and then just output the entire buffer.
